### PR TITLE
Fix code scanning alert no. 6: Use of insecure SSL/TLS version

### DIFF
--- a/chapter10/ssl/ssl_client_check_certificate.py
+++ b/chapter10/ssl/ssl_client_check_certificate.py
@@ -14,7 +14,11 @@ if __name__ == '__main__':
 	client_sock = socket.socket(socket.AF_INET,socket.SOCK_STREAM)
 	client_sock.connect((hostname, 443))
 	# Turn the socket over to the SSL library
-	ssl_socket = ssl.wrap_socket(client_sock, ssl_version=ssl.PROTOCOL_TLSv1,cert_reqs=ssl.CERT_REQUIRED, ca_certs=CA_CERT_PATH)
+	context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+	context.minimum_version = ssl.TLSVersion.TLSv1_2
+	context.verify_mode = ssl.CERT_REQUIRED
+	context.load_verify_locations(CA_CERT_PATH)
+	ssl_socket = context.wrap_socket(client_sock, server_hostname=hostname)
 	print(ssl_socket.cipher())
 	try:
 		ssl.match_hostname(ssl_socket.getpeercert(), hostname)


### PR DESCRIPTION
Fixes [https://github.com/ibiscum/Learning-Python-Networking-Second-Edition/security/code-scanning/6](https://github.com/ibiscum/Learning-Python-Networking-Second-Edition/security/code-scanning/6)

To fix the problem, we need to ensure that a secure protocol version is used. The best way to do this is to replace the deprecated `ssl.wrap_socket` method with `ssl.SSLContext`, which allows us to specify a minimum protocol version. We will use `ssl.PROTOCOL_TLS_CLIENT` and set the `minimum_version` to `ssl.TLSVersion.TLSv1_2` to ensure that only TLS 1.2 and above are used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
