### PR TITLE
Fix code scanning alert no. 4: Accepting unknown SSH host keys when using Paramiko

### DIFF
--- a/Chapter06/paramiko/ssh_interactive_shell.py
+++ b/Chapter06/paramiko/ssh_interactive_shell.py
@@ -7,7 +7,7 @@ class ShellHandler:
 
     def __init__(self, host, user, psw): 
         self.ssh = paramiko.SSHClient() 
-        self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy()) 
+        self.ssh.set_missing_host_key_policy(paramiko.RejectPolicy()) 
         self.ssh.connect(host, username=user, password=psw, port=22) 
 
         channel = self.ssh.invoke_shell() 


### PR DESCRIPTION
Fixes [https://github.com/ibiscum/Learning-Python-Networking-Second-Edition/security/code-scanning/4](https://github.com/ibiscum/Learning-Python-Networking-Second-Edition/security/code-scanning/4)

To fix the problem, we need to replace the `AutoAddPolicy` with `RejectPolicy` to ensure that only known and trusted host keys are accepted. This change will prevent the SSH client from automatically trusting unknown host keys, thereby mitigating the risk of man-in-the-middle attacks.

**Steps to fix:**
1. Replace `paramiko.AutoAddPolicy()` with `paramiko.RejectPolicy()` on line 10.
2. Ensure that the host key for the server is added to the known hosts file or manually add it to the SSH client before attempting to connect.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
